### PR TITLE
Capwap cannot be built in debian stable

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -22,7 +22,7 @@ AC_PREREQ(2.63)
 AC_INIT([SmartCAPWAP], [1.1.0], [https://github.com/travelping/smartcapwap], [smartcapwap])
 AC_CONFIG_AUX_DIR([build])
 AC_CONFIG_MACRO_DIR([m4])
-AM_INIT_AUTOMAKE([1.11 -Wall])
+AM_INIT_AUTOMAKE([1.11 subdir-objects -Wall])
 AC_USE_SYSTEM_EXTENSIONS
 
 # cross-compile macros


### PR DESCRIPTION
There is an option missing in configure.ac:

# autoreconf -f -i 
build/Makefile_common.am:20: warning: source file '$(top_srcdir)/src/common/capwap.c' is in a subdirectory,
build/Makefile_common.am:20: but option 'subdir-objects' is disabled
build/ac/Makefile.am:37:   'build/Makefile_common.am' included from here
automake: warning: possible forward-incompatibility.
automake: At least a source file is in a subdirectory, but the 'subdir-objects'
automake: automake option hasn't been enabled.  For now, the corresponding output
automake: object file(s) will be placed in the top-level directory.  However,
automake: this behaviour will change in future Automake versions: they will
automake: unconditionally cause object files to be placed in the same subdirectory
automake: of the corresponding sources.
automake: You are advised to start using 'subdir-objects' option throughout your
automake: project, to avoid future incompatibilities.
build/Makefile_common.am:20: warning: source file '$(top_srcdir)/src/common/capwap_timeout.c' is in a subdirectory,
build/Makefile_common.am:20: but option 'subdir-objects' is disabled
build/ac/Makefile.am:37:   'build/Makefile_common.am' included from here
build/Makefile_common.am:20: warning: source file '$(top_srcdir)/src/common/capwap_network.c' is in a subdirectory,
[...]