### PR TITLE
Bugfix for memcmp of struct failing on PPC hardware

### DIFF
--- a/src/common/capwap_element.c
+++ b/src/common/capwap_element.c
@@ -138,8 +138,7 @@ struct capwap_list_item* capwap_get_message_element(struct capwap_parsed_packet*
 	while (search) {
 		struct capwap_message_element_itemlist* messageelement =
 			(struct capwap_message_element_itemlist*)search->item;
-
-		if (memcmp(&messageelement->id, &id, sizeof(id)) == 0)
+		if ((id.vendor == messageelement->id.vendor) && (id.type == messageelement->id.type))
 			return search;
 
 		/* */


### PR DESCRIPTION
Probably the padding of the id strzuct made memcmp fail. 